### PR TITLE
Fix cancel research/building queues error

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -140,10 +140,7 @@ function _date($format, $time = null, $toTimeZone = null, $LNG = NULL)
 		$date = new DateTime();
 		if(method_exists($date, 'setTimestamp'))
 		{	// PHP > 5.3			
-			$time	= round(TIMESTAMP);
-			$tempDate = getdate((int) $time);
-			$date->setDate($tempDate['year'], $tempDate['mon'], $tempDate['mday']);
-			$date->setTime($tempDate['hours'], $tempDate['minutes'], $tempDate['seconds']);
+			$date->setTimestamp($time);
 		} else {
 			// PHP < 5.3
 			$tempDate = getdate((int) $time);

--- a/includes/pages/game/ShowBuildingsPage.class.php
+++ b/includes/pages/game/ShowBuildingsPage.class.php
@@ -93,7 +93,7 @@ class ShowBuildingsPage extends AbstractGamePage
             return;
         }
 
-		$Element		= $CurrentQueue[$QueueID - 2][0];
+		$Element		= $CurrentQueue[$QueueID - 1][0];
 		$BuildEndTime	= $CurrentQueue[$QueueID - 2][3];
 		unset($CurrentQueue[$QueueID - 1]);
 		$NewQueueArray	= array();
@@ -105,7 +105,7 @@ class ShowBuildingsPage extends AbstractGamePage
 				if($Element == $ListIDArray[0] || empty($ListIDArray[0]))
 					continue;
 
-				$BuildEndTime       += BuildFunctions::getBuildingTime($USER, $PLANET, $ListIDArray[0], NULL, $ListIDArray[4] == 'destroy', $ListIDArray[2]);
+				$BuildEndTime       += BuildFunctions::getBuildingTime($USER, $PLANET, $ListIDArray[0], NULL, $ListIDArray[4] == 'destroy', $ListIDArray[1]);
 				$ListIDArray[3]		= $BuildEndTime;
 				$NewQueueArray[]	= $ListIDArray;				
 			}

--- a/includes/pages/game/ShowResearchPage.class.php
+++ b/includes/pages/game/ShowResearchPage.class.php
@@ -58,7 +58,7 @@ class ShowResearchPage extends AbstractGamePage
 		$db = Database::get();
 
 		$elementId		= $USER['b_tech_id'];
-		$costResources	= BuildFunctions::getElementPrice($USER, $PLANET, $elementId, false, $PLANET[$elementId] + 1);
+		$costResources	= BuildFunctions::getElementPrice($USER, $PLANET, $elementId, false, $USER[$resource[$elementId]] + 1);
 		
 		if($PLANET['id'] == $USER['b_tech_planet'])
 		{


### PR DESCRIPTION
1. Fix of error when cancelling research

>Message: Undefined offset: 120
File: /includes/pages/game/ShowResearchPage.class.php
Line: 61
URL: http://steemnova.intinte.org/game.php?page=research
PHP-Version: 7.0.19-1
PHP-API: fpm-fcgi
2Moons Version: 1.8.git
Debug Backtrace:
#0 /includes/pages/game/ShowResearchPage.class.php(61): errorHandler(8, 'Undefined offse...', 'FILEPATH ...', 61, Array)
#1 /includes/pages/game/ShowResearchPage.class.php(342): ShowResearchPage->CancelBuildingFromQueue()
#2 /game.php(57): ShowResearchPage->show()
#3 {main}

Misstyped $USER[$resource] with $PLANET?

---

2. Fix of error when cancelling queued building

>Message: DateTime::setTimestamp() expects parameter 1 to be integer, float given
File: /includes/GeneralFunctions.php
Line: 143
URL: http://steemnova.intinte.org/game.php?page=buildings
PHP-Version: 7.0.22-0ubuntu0.16.04.1
PHP-API: apache2handler
2Moons Version: 1.8.git
Debug Backtrace:
#0 [internal function]: errorHandler(2, 'DateTime::setTi...', 'FILEPATH ...', 143, Array)
#1 /includes/GeneralFunctions.php(143): DateTime->setTimestamp(6.3588806566614E+209)
#2 /includes/pages/game/ShowBuildingsPage.class.php(231): _date('U', 6.3588806566614E+209, 'Europe/Berlin')
#3 /includes/pages/game/ShowBuildingsPage.class.php(271): ShowBuildingsPage->getQueueData()
#4 /game.php(57): ShowBuildingsPage->show()
#5 {main}

$ListIDArray[] values mistake? Original code was scaling build time as a "estimated cost" instead of "building level" power of estimated build end time. Giving enormous numbers (E+209 ~INF)