### PR TITLE
Fix PHP MySQL incorrect planet sorting

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -70,7 +70,7 @@ function getPlanets($USER)
 			$sql	.= 'id '.$order;
 			break;
 		case 1:
-			$sql	.= 'galaxy, system, planet, planet_type '.$order;
+			$sql	.= 'galaxy '.$order.', system '.$order.', planet '.$order.', planet_type '.$order;
 			break;
 		case 2:
 			$sql	.= 'name '.$order;

--- a/includes/pages/game/ShowImperiumPage.class.php
+++ b/includes/pages/game/ShowImperiumPage.class.php
@@ -30,30 +30,29 @@ class ShowImperiumPage extends AbstractGamePage
 		global $USER, $PLANET, $resource, $reslist;
 
         $db = Database::get();
+		
+		$order = $USER['planet_sort_order'] == 1 ? 'DESC' : 'ASC';
+		
+		$sql = "SELECT * FROM %%PLANETS%% WHERE id_owner = :userID AND destruyed = '0' ORDER BY ";
 
 		switch($USER['planet_sort'])
 		{
 			case 2:
-				$orderBy = 'name';
+				$sql .= 'name '.$order;
 				break;
 			case 1:
-				$orderBy = 'galaxy, system, planet, planet_type';
+				$sql .= 'galaxy '.$order.', system '.$order.', planet '.$order.', planet_type '.$order;
 				break;
 			default:
-				$orderBy = 'id';
+				$sql .= 'id '.$order;
 				break;
 		}
-		
-		$orderBy .= ' '.($USER['planet_sort_order'] == 1) ? 'DESC' : 'ASC';
 
-        $sql = "SELECT * FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND destruyed = '0' ORDER BY :order;";
         $PlanetsRAW = $db->select($sql, array(
-            ':planetID' => $PLANET['id'],
-            ':userID'   => $USER['id'],
-            ':order'    => $orderBy,
+            ':userID'   => $USER['id']
         ));
 
-        $PLANETS	= array($PLANET);
+        $PLANETS	= array();
 		
 		$PlanetRess	= new ResourceUpdate();
 		

--- a/includes/pages/game/ShowInformationPage.class.php
+++ b/includes/pages/game/ShowInformationPage.class.php
@@ -163,26 +163,27 @@ class ShowInformationPage extends AbstractGamePage
 
 		$db = Database::get();
 
-		$Order = $USER['planet_sort_order'] == 1 ? "DESC" : "ASC" ;
-		$Sort  = $USER['planet_sort'];
+		$order = $USER['planet_sort_order'] == 1 ? "DESC" : "ASC" ;
+		$sort  = $USER['planet_sort'];
+		
+		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, ".$resource[43]." FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND ".$resource[43]." > 0 ORDER BY ";
 
-		switch($Sort) {
+		switch($sort) {
 			case 1:
-				$OrderBy	= "galaxy, system, planet, planet_type ". $Order;
+				$sql .= 'galaxy '.$order.', system '.$order.', planet '.$order.', planet_type '.$order;
 				break;
 			case 2:
-				$OrderBy	= "name ". $Order;
+				$sql .= 'name '.$order;
 				break;
 			default:
-				$OrderBy	= "id ". $Order;
+				$sql .= 'id '.$order;
 				break;
 		}
 
-		$sql = "SELECT id, name, galaxy, system, planet, last_jump_time, ".$resource[43]." FROM %%PLANETS%% WHERE id != :planetID AND id_owner = :userID AND planet_type = '3' AND ".$resource[43]." > 0 ORDER BY :order;";
+		
 		$moonResult = $db->select($sql, array(
 			':planetID'         => $PLANET['id'],
-			':userID'           => $USER['id'],
-			':order'            => $OrderBy
+			':userID'           => $USER['id']
 		));
 
 		$moonList	= array();


### PR DESCRIPTION
2 MySQL bugs in PHP code:

1. Prepared statements cannot be used for dynamic parametrized queries like "ORDER BY name DESC" or "ASC". I have moved out the paremeters of DESC/ASC from prepared statements.
2. In multiple ORDER BY statements, the DESC/ASC should occur after every column we filter on.

Eg.:

>mysql> select name,galaxy,system,planet from uni1_planets where id_owner=1 and destruyed=0 order by galaxy,system,planet DESC;
+----------------+--------+--------+--------+
| name           | galaxy | system | planet |
+----------------+--------+--------+--------+
| Zamek          |      1 |      1 |      6 |
| Planeta domowa |      1 |      1 |      2 |
| Kolonia        |      1 |      2 |      1 |
+----------------+--------+--------+--------+

Correct:
>mysql> select name,galaxy,system,planet from uni1_planets where id_owner=1 and destruyed=0 order by galaxy DESC, system DESC ,planet DESC;
+----------------+--------+--------+--------+
| name           | galaxy | system | planet |
+----------------+--------+--------+--------+
| Kolonia        |      1 |      2 |      1 |
| Zamek          |      1 |      1 |      6 |
| Planeta domowa |      1 |      1 |      2 |
+----------------+--------+--------+--------+