### PR TITLE
Display the right technology on click

### DIFF
--- a/styles/templates/game/page.techTree.default.tpl
+++ b/styles/templates/game/page.techTree.default.tpl
@@ -14,7 +14,7 @@
 	<td>
 	{if $requireList}
 		{foreach $requireList as $requireID => $NeedLevel}
-			<a href="#" onclick="return Dialog.info({$elementID})"><span style="color:{if $NeedLevel.own < $NeedLevel.count}red{else}lime{/if};">{$LNG.tech.$requireID} ({$LNG.tt_lvl} {min($NeedLevel.count, $NeedLevel.own)}/{$NeedLevel.count})</span></a>{if !$NeedLevel@last}<br>{/if}
+			<a href="#" onclick="return Dialog.info({$requireID})"><span style="color:{if $NeedLevel.own < $NeedLevel.count}red{else}lime{/if};">{$LNG.tech.$requireID} ({$LNG.tt_lvl} {min($NeedLevel.count, $NeedLevel.own)}/{$NeedLevel.count})</span></a>{if !$NeedLevel@last}<br>{/if}
 		{/foreach}
 	{/if}
 	</td>


### PR DESCRIPTION
If you click on a required technology in the techtree it opens the false technology. 
A click on "roboterfabrik":
![image](https://user-images.githubusercontent.com/6072971/36346586-f9d5615e-1440-11e8-9af8-9083e4b61489.png)
opens "Nanitenfabrik":
![image](https://user-images.githubusercontent.com/6072971/36346588-00ff5e6c-1441-11e8-8ad0-9d3bfdc8a357.png)


This pullrequest fixes this 👍 