### PR TITLE
Fixed confirmation dialog

### DIFF
--- a/styles/templates/game/page.marketPlace.default.tpl
+++ b/styles/templates/game/page.marketPlace.default.tpl
@@ -134,7 +134,7 @@ $('#shipT').on('change', function (e) {
 $('#shipT').trigger("change");
 
 $(".market_form").submit( function() {
-	var c = confirm({$LNG.market_confirm_are_you_sure});
+	var c = confirm("{$LNG.market_confirm_are_you_sure}");
 	if (c) {
 		$(this).append('<input type="hidden" name="shipType" value="' + $("#shipT").val() + '">')
 	}


### PR DESCRIPTION
Fix the issue that will be created by [my post](https://utopian.io/utopian-io/@mwfiae/steemnova-marketplace-bug-no-confirmation-message-for-trading)