### PR TITLE
Change resource name color back to red

### DIFF
--- a/styles/templates/game/main.topnav.tpl
+++ b/styles/templates/game/main.topnav.tpl
@@ -30,7 +30,9 @@
 									{foreach $resourceTable as $resourceID => $resourceData}
 									<td class="res_name">
 										<a href="#" onclick="return Dialog.info({$resourceID});">
-										{$LNG.tech.$resourceID}
+											<span style="color:red">
+											{$LNG.tech.$resourceID}
+											</span>
 										</a>
 									</td>
 									{/foreach}


### PR DESCRIPTION
This was caused through my previous pull request, and caused the color of the, now clickable, resource name to go white instead of red.