### PR TITLE
Debug errors via support ticket

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -572,6 +572,22 @@ function exceptionHandler($exception)
 	{
 		file_put_contents('includes/error.log', $errorText, FILE_APPEND);
 	}
+	
+	/* Debug via Support Ticket */
+	global $USER;
+	if(isset($USER))
+	{
+		$ErrSource = $USER['id'];
+		$ErrName = $USER['username'];
+	}else{
+		$ErrSource = 1;
+		$ErrName = 'System';
+	}
+	require 'includes/classes/class.SupportTickets.php';
+	$ticketObj	= new SupportTickets;
+	$ticketID	= $ticketObj->createTicket($ErrSource, '1', $errorType[$errno]);
+	$ticketObj->createAnswer($ticketID, $ErrSource, $ErrName, $errorType[$errno], $errorText, 0);
+	
 }
 /*
  *


### PR DESCRIPTION
This could be helpful if a user experience an error and we do not know how it happened until we check error.log file and get lost on the quantity of information there.

As long there's something malfunctioning on game core, we will always get a support ticket with detailed tracking just like when user had the error on his screen.