### PR TITLE
vars factor 'Expedition' has no use

### DIFF
--- a/includes/classes/class.FleetFunctions.php
+++ b/includes/classes/class.FleetFunctions.php
@@ -82,7 +82,7 @@ class FleetFunctions
 
 	public static function getExpeditionLimit($USER)
 	{
-		return floor(sqrt($USER[$GLOBALS['resource'][124]]));
+		return floor(sqrt($USER[$GLOBALS['resource'][124]])) + $USER['factor']['Expedition'];
 	}
 
 	public static function getDMMissionLimit($USER)

--- a/includes/pages/game/ShowFleetTablePage.class.php
+++ b/includes/pages/game/ShowFleetTablePage.class.php
@@ -193,7 +193,7 @@ class ShowFleetTablePage extends AbstractGamePage
 		if ($techExpedition >= 1)
 		{
 			$activeExpedition   = FleetFunctions::GetCurrentFleets($USER['id'], 15, true);
-			$maxExpedition 		= floor(sqrt($techExpedition));
+			$maxExpedition 		= floor(sqrt($techExpedition)) + $USER['factor']['Expedition'];
 		}
 		else
 		{


### PR DESCRIPTION
It was intended first to be used to give additional expedition slots, but this vars attribute currently does not give anything to the game.