### PR TITLE
Fix div by zero for deut consumption

### DIFF
--- a/includes/classes/class.FleetFunctions.php
+++ b/includes/classes/class.FleetFunctions.php
@@ -184,7 +184,7 @@ class FleetFunctions
 			$ShipSpeed          = self::GetShipSpeed($Ship, $Player);
 			$ShipConsumption    = self::GetShipConsumption($Ship, $Player);
 
-			$spd                = 35000 / (round($MissionDuration, 0) * $GameSpeed - 10) * sqrt($MissionDistance * 10 / $ShipSpeed);
+			$spd                = 35000 / max($MissionDuration * $GameSpeed - 10, 1) * sqrt($MissionDistance * 10 / $ShipSpeed);
 			$basicConsumption   = $ShipConsumption * $Count;
 			$consumption        += $basicConsumption * $MissionDistance / 35000 * (($spd / 10) + 1) * (($spd / 10) + 1);
 		}

--- a/scripts/game/flotten.js
+++ b/scripts/game/flotten.js
@@ -42,7 +42,7 @@ function GetConsumption() {
 	var basicConsumption = 0;
 	var i;
 	$.each(data.ships, function(shipid, ship){
-		spd = 35000 / (dataFlyTime * data.gamespeed - 10) * Math.sqrt(dataFlyDistance * 10 / ship.speed);
+		spd = 35000 / Math.max(dataFlyTime * data.gamespeed - 10, 1) * Math.sqrt(dataFlyDistance * 10 / ship.speed);
 		basicConsumption = ship.consumption * ship.amount;
 		dataFlyConsumption2 += basicConsumption * dataFlyDistance / 35000 * (spd / 10 + 1) * (spd / 10 + 1);
 	});


### PR DESCRIPTION
fix #172 
Set deuterium consumption to 1 as minimum (div by zero occurs at GameSpeed=2 for shortest distances).