### PR TITLE
Update install.sql

### DIFF
--- a/install/install.sql
+++ b/install/install.sql
@@ -659,7 +659,7 @@ CREATE TABLE `%PREFIX%statpoints` (
   `total_old_rank` int(11) unsigned NOT NULL DEFAULT '0',
   `total_points` double(50,0) unsigned NOT NULL DEFAULT '0',
   `total_count` bigint(20) unsigned NOT NULL DEFAULT '0',
-  KEY `id_owner` (`id_owner`),
+  PRIMARY KEY `id_owner` (`id_owner`),
   KEY `universe` (`universe`),
   KEY `stat_type` (`stat_type`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
BUG: Truncate table method in stat updates causes problems, while script is working to update stats, ( in crowded servers ) stat information is lost about 5 - 10 seconds. 

Solution: Instead of Truncate table method, insert into table on duplicate key update should be used. Therefore we need 1 primary key in uni1_statpoints table.